### PR TITLE
Change opencv cersion in order to read mp4 file

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.0.2
 numpy==1.16.3
-opencv-python>=4.0.1.23
+opencv-python==4.0.1.23
 Pillow==8.2.0
 redis==3.2.1


### PR DESCRIPTION
for latest opencv-python==4.5.1.48 
reading mp4 file will fail and cause CAP_PROP_FPS become zero 
https://github.com/RedisGears/EdgeRealtimeVideoAnalytics/blob/8e2d3be647fd6bf091fb7837a9c2b01787a70b81/app/capture.py#L37-L38