### PR TITLE
Fixing libgl issue in base docker

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,10 @@
-FROM python:3.7.3
+FROM python:3.7.12
 
 WORKDIR /app
 ADD . /app
+RUN apt-get update -qyy
+RUN apt-get install -y  python3-opencv
+RUN apt-get remove -y python3-opencv
 
 RUN pip install --upgrade pip
 RUN set -ex; \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,5 +9,6 @@ RUN apt-get remove -y python3-opencv
 RUN pip install --upgrade pip
 RUN set -ex; \
     pip install -r requirements.txt;
+RUN rm -rf ~/.cache/pip /var/cache/apt/
 
 ENTRYPOINT [ "python3" ]


### PR DESCRIPTION
opencv needs a library that's no longer present in the image of the base docker (python 3.7.3). Upgraded to the latest python docker for this verison (3.7.12), installed the removed the python3-opencv package. The reason for the latter is to force the **correct** dependencies to be installed. We then proceed and build as usual, pinning our opencv version.

closes #86 