### PR TITLE
ugrade flask to fix ImportError: cannot import name 'Markup' from 'jinja'

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.2
+Flask==2.0.3
 numpy==1.16.3
 opencv-python>=4.0.1.23
 Pillow==8.3.2


### PR DESCRIPTION
Hi,

This pull request is fixing server that deosnot start complaining ImportError: cannot import name 'Markup' from 'jinja'.
Upgrading flask solve the problem (see https://stackoverflow.com/questions/71645272/importerror-cannot-import-name-markup-from-jinja2)

Best Regards,
Michel.